### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -163,7 +163,7 @@ class JWProxy {
     if (body && body.sessionId && this.sessionId) {
       body.sessionId = this.sessionId;
     }
-    res.send(response.statusCode, JSON.stringify(body));
+    res.status(response.statusCode).send(JSON.stringify(body));
   }
 }
 

--- a/test/proxy-specs.js
+++ b/test/proxy-specs.js
@@ -15,11 +15,15 @@ function buildReqRes (url, method, body) {
   let res = {};
   res.headers = {};
   res.set = (k, v) => { res[k] = v; };
-  res.send = (code, body) => {
+  res.status = (code) => {
+    res.sentCode = code;
+    return res;
+  };
+  res.send = (body) => {
     try {
       body = JSON.parse(body);
     } catch (e) {}
-    res.sentCode = code; res.sentBody = body;
+    res.sentBody = body;
   };
   return [req, res];
 }


### PR DESCRIPTION
This PR fixes deprecation message from appium 1.4.0-beta:

```
info: Got response with status 200: {"sessionId":"f1ec2712213e669957a808fc7558f8de","status":0,"value":{"acceptSslCerts":true,"applicationCacheEnabled":false,"browserConnectionEnabled":false,"browserName":"chrome","chrome":{},"cssSelect...
express deprecated res.send(status, body): Use res.status(status).send(body) instead node_modules/appium-chromedriver/node_modules/appium-jsonwp-proxy/build/lib/proxy.js:298:17
info: <-- GET /wd/hub/session/7cec9309-d7d2-4276-9c72-bda5fd76ae69 200 8.173 ms - 507
```
