### PR TITLE
Replacing response sessionId with sessionId in url

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -154,16 +154,28 @@ class JWProxy {
     throw new Error(`Didn't know what to do with response code ${response.statusCode}`);
   }
 
+  getSessionIdFromUrl (url) {
+    const match = url.match(/\/session\/([^\/]+)/);
+    return match ? match[1] : null;
+  }
+
   async proxyReqRes (req, res) {
     let [response, body] = await this.proxy(req.originalUrl, req.method, req.body);
     res.headers = response.headers;
     res.set('Content-type', response.headers['content-type']);
     // if the proxied response contains a sessionId that the downstream
     // driver has generated, we don't want to return that to the client.
-    // Instead, return the id for the current session
+    // Instead, return the id from the request or from current session
     body = safeJson(body);
-    if (body && body.sessionId && this.sessionId) {
-      body.sessionId = this.sessionId;
+    if (body && body.sessionId) {
+      const reqSessionId = this.getSessionIdFromUrl(req.originalUrl);
+      if (reqSessionId) {
+        log.info(`Replacing sessionId ${body.sessionId} with ${reqSessionId}`);
+        body.sessionId = reqSessionId;
+      } else if (this.sessionId) {
+        log.info(`Replacing sessionId ${body.sessionId} with ${this.sessionId}`);
+        body.sessionId = this.sessionId;
+      }
     }
     res.status(response.statusCode).send(JSON.stringify(body));
   }

--- a/test/proxy-specs.js
+++ b/test/proxy-specs.js
@@ -136,6 +136,12 @@ describe('proxy', () => {
       await j.proxyReqRes(req, res);
       res.sentBody.should.eql({status: 0, value: 'foobar', sessionId: '123'});
     });
+    it('should rewrite the inner session id with sessionId in url', async () => {
+      let j = mockProxy({sessionId: '123'});
+      let [req, res] = buildReqRes('/wd/hub/session/456/element/200/value', 'POST');
+      await j.proxyReqRes(req, res);
+      res.sentBody.should.eql({status: 0, value: 'foobar', sessionId: '456'});
+    });
     it('should proxy strange responses', async () => {
       let j = mockProxy({sessionId: '123'});
       let [req, res] = buildReqRes('/nochrome', 'GET');


### PR DESCRIPTION
- Added code and test for replacing response sessionId with sessionId present in url
- ping @jlipps @sebv 
