### PR TITLE
fixed a bug where we weren't able to properly process requests to the…

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -52,44 +52,45 @@ class JWProxy {
     if (url === "") url = "/";
     const proxyBase = `${this.scheme}://${this.server}:${this.port}${this.base}`;
     const endpointRe = '(/(session|status))';
-    let rest = "";
+    let remainingUrl = "";
     if (/^http/.test(url)) {
       const first = (new RegExp('(https?://.+)' + endpointRe)).exec(url);
       if (!first) {
         throw new Error("Got a complete url but could not extract JWP endpoint");
       }
-      rest = url.replace(first[1], '');
+      remainingUrl = url.replace(first[1], '');
     } else if ((new RegExp('^/')).test(url)) {
-      rest = url;
+      remainingUrl = url;
     } else {
       throw new Error("Didn't know what to do with url '" + url + "'");
     }
-    const requiresSessionId = this.endpointRequiresSessionId(rest);
+
+    const stripPrefixRe = new RegExp('^.+(/(session|status).*)$');
+    if (stripPrefixRe.test(remainingUrl)) {
+      remainingUrl = stripPrefixRe.exec(remainingUrl)[1];
+    }
+
+    if (!(new RegExp(endpointRe)).test(remainingUrl)) {
+      remainingUrl = `/session/${this.sessionId}${remainingUrl}`;
+    }
+
+    const requiresSessionId = this.endpointRequiresSessionId(remainingUrl);
 
     if (requiresSessionId && this.sessionId === null) {
       throw new Error("Trying to proxy a session command without session id");
     }
 
-    const stripPrefixRe = new RegExp('^.+(/(session|status).*)$');
-    if (stripPrefixRe.test(rest)) {
-      rest = stripPrefixRe.exec(rest)[1];
-    }
-
-    if (!(new RegExp(endpointRe)).test(rest)) {
-      rest = `/session/${this.sessionId}${rest}`;
-    }
-
     const sessionBaseRe = new RegExp('^/session/([^/]+)');
-    if (sessionBaseRe.test(rest)) {
+    if (sessionBaseRe.test(remainingUrl)) {
       // we have something like /session/:id/foobar, so we need to replace
       // the session id
-      const match = sessionBaseRe.exec(rest);
-      rest = rest.replace(match[1], this.sessionId);
+      const match = sessionBaseRe.exec(remainingUrl);
+      remainingUrl = remainingUrl.replace(match[1], this.sessionId);
     } else if (requiresSessionId) {
-      throw new Error("Got bad session base with rest of url: " + rest);
+      throw new Error(`Could not find :session section for url: ${remainingUrl}`);
     }
-    rest = rest.replace(/\/$/, ''); // can't have trailing slashes
-    return proxyBase + rest;
+    remainingUrl = remainingUrl.replace(/\/$/, ''); // can't have trailing slashes
+    return proxyBase + remainingUrl;
   }
 
   async proxy (url, method, body = null) {


### PR DESCRIPTION
… /status endpoint. related to appium #5335. Added tests. We should now properly proxy all commands that don't require a session id in the url
